### PR TITLE
Fix Google Search Console indexing issues

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -303,6 +303,10 @@ html_copy_source = False
 # Point 6: SEO - Add canonical URLs
 html_baseurl = "https://spdlearn.org/"
 
+# Fix sitemap URLs - current deployment is single-version at root,
+# so don't prefix with language/version directories
+sitemap_url_scheme = "{link}"
+
 # Point 7: Copy root-level site files (robots.txt, BingSiteAuth.xml, etc.)
 html_extra_path = ["_extra"]
 
@@ -549,3 +553,14 @@ def linkcode_resolve(domain, info):
         pass
 
     return f"https://github.com/{github_user}/{github_repo}/blob/{github_version}/{relpath}{linespec}"
+
+
+def _fix_index_canonical_url(app, pagename, templatename, context, doctree):
+    """Strip index.html from canonical URLs so Google indexes clean directory URLs."""
+    pageurl = context.get("pageurl", "")
+    if pageurl and pageurl.endswith("/index.html"):
+        context["pageurl"] = pageurl[: -len("index.html")]
+
+
+def setup(app):
+    app.connect("html-page-context", _fix_index_canonical_url)


### PR DESCRIPTION
Closes #13

## Summary

- **Fix broken sitemap URLs**: Set `sitemap_url_scheme = "{link}"` to remove the incorrect `en/0.1/` prefix from all 179 URLs in `sitemap.xml`. The default `{lang}{version}{link}` scheme doesn't match our single-version deployment at root.
- **Fix homepage canonical tag**: Add a Sphinx `html-page-context` hook that strips trailing `index.html` from canonical URLs, so the homepage canonical becomes `https://spdlearn.org/` instead of `https://spdlearn.org/index.html`.

## Verification

After building locally:

**Sitemap** — no `en/0.1/` prefix:
```
<loc>https://spdlearn.org/api.html</loc>
```

**Canonical tag** on `index.html`:
```html
<link rel="canonical" href="https://spdlearn.org/" />
```

## After deploying

- Resubmit sitemap in Google Search Console
- Request validation of both indexing issues
- Verify "Enforce HTTPS" is enabled in GitHub Pages settings