### PR TITLE
Fix: quote extras install commands for zsh compatibility

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -49,7 +49,7 @@ For EEG and fMRI applications:
 
 .. code-block:: bash
 
-   pip install spd_learn[brain]
+   pip install "spd_learn[brain]"
 
 This installs:
 
@@ -64,7 +64,7 @@ To build the documentation locally:
 
 .. code-block:: bash
 
-   pip install spd_learn[docs]
+   pip install "spd_learn[docs]"
 
 Testing
 ^^^^^^^
@@ -73,7 +73,7 @@ For running the test suite:
 
 .. code-block:: bash
 
-   pip install spd_learn[tests]
+   pip install "spd_learn[tests]"
 
 All Dependencies
 ^^^^^^^^^^^^^^^^
@@ -82,7 +82,7 @@ To install all optional dependencies:
 
 .. code-block:: bash
 
-   pip install spd_learn[all]
+   pip install "spd_learn[all]"
 
 Verifying Installation
 ----------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,6 @@ docs = [
 brain = [
     'moabb',
     'braindecode',
-    'moabb',
     'nilearn',
     'pyriemann',
     'skada',


### PR DESCRIPTION
## Summary
- Quote all `pip install` extras commands in docs (`"spd_learn[brain]"`, `"spd_learn[docs]"`, etc.) to prevent zsh `no matches found` errors
- Remove duplicate `moabb` entry from `brain` extras in `pyproject.toml`

Closes #17

## Test plan
- [ ] `pip install "spd_learn[brain]" --dry-run` resolves correctly
- [ ] Docs build without RST errors