### PR TITLE
Add Sphinx-Gallery caching and stabilize CI cache keys

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,16 +43,24 @@ jobs:
       - name: Test documentation code blocks
         run: pytest docs/ -v
 
-      - name: Create/Restore Data Caches mne and Nilearn
+      - name: Create/Restore Data Caches
         id: cache-data
         uses: actions/cache@v4
         with:
           path: |
             ~/mne_data
             ~/nilearn_data
-          key: ${{ runner.os }}-data-${{ github.run_id }}
+          key: ${{ runner.os }}-data-v1
           restore-keys: |
             ${{ runner.os }}-data
+
+      - name: Restore Sphinx-Gallery Cache
+        uses: actions/cache@v4
+        with:
+          path: docs/source/generated/
+          key: ${{ runner.os }}-gallery-${{ hashFiles('examples/**/*.py') }}
+          restore-keys: |
+            ${{ runner.os }}-gallery-
 
       - name: Build Docs
         run: make -C docs html

--- a/.github/workflows/install-tests.yml
+++ b/.github/workflows/install-tests.yml
@@ -49,7 +49,7 @@ jobs:
           path: |
             ~/mne_data
             ~/nilearn_data
-          key: ${{ runner.os }}-${{ matrix.python-version }}-data-${{ github.run_id }}
+          key: ${{ runner.os }}-${{ matrix.python-version }}-data-v1
           restore-keys: |
             ${{ runner.os }}-${{ matrix.python-version }}-data
 
@@ -103,7 +103,7 @@ jobs:
           path: |
             ~/mne_data
             ~/nilearn_data
-          key: ${{ runner.os }}-integration-data-${{ github.run_id }}
+          key: ${{ runner.os }}-integration-data-v1
           restore-keys: |
             ${{ runner.os }}-integration-data
 


### PR DESCRIPTION
## Summary

- Add Sphinx-Gallery output caching in `docs.yml` keyed by `hashFiles('examples/**/*.py')`, so unchanged examples skip re-execution on subsequent builds
- Stabilize data cache keys in both `docs.yml` and `install-tests.yml` by replacing `github.run_id` with a fixed `v1` suffix — downloaded datasets (MNE, Nilearn) don't change between runs, so the `run_id`-based key was creating unnecessary cache entries

## Context

Current docs build on main takes ~23 min. PR #21 adds a heavy example (`plot_liebn_batch_normalization.py`) that causes builds to hang for 6+ hours. This PR provides caching infrastructure so that once examples are built, they won't re-run unless the example scripts change.

## Test plan

- [x] Verify docs CI completes successfully
- [ ] On a second push with no example changes, verify gallery cache is restored (check "Restore Sphinx-Gallery Cache" step output)