### PR TITLE
Fix : add gradient w.r.t. exponent in matrix_power backward 

### DIFF
--- a/spd_learn/functional/core.py
+++ b/spd_learn/functional/core.py
@@ -377,7 +377,7 @@ class matrix_power(Function):
     ----------
     X : torch.Tensor
         Symmetric matrix of shape `(..., n, n)`.
-    exponent : float
+    exponent : torch.Tensor
         Exponent to raise the matrix to.
 
     Returns
@@ -425,16 +425,16 @@ class matrix_power(Function):
         exponent = ctx.exponent
         threshold = get_epsilon(s.dtype, "eigval_power")
 
-        # Gradient wrt the exponent
-        G = U.transpose(-1,-2) @ grad_output @ U
-        diag_G = torch.diagonal(G, dim1 = -2, dim2= -1)
+        # Gradient w.r.t the exponent
+        G = U.transpose(-1, -2) @ grad_output @ U
+        diag_G = torch.diagonal(G, dim1=-2, dim2=-1)
 
-        s_safe = s.clamp(min = threshold)
+        s_safe = s.clamp(min=threshold)
         exp_g = s_modified * torch.log(s_safe)
 
-        grad_exponent = torch.sum(diag_G * exp_g).view(1, 1)
+        grad_exponent = torch.sum(diag_G * exp_g, dim=-1).sum().reshape_as(exponent)
 
-        # Gradient wrt X
+        # Gradient w.r.t X
         grad_X = modeig_backward(
             grad_output, s, U, s_modified, matrix_power.derivative, exponent
         )

--- a/spd_learn/functional/core.py
+++ b/spd_learn/functional/core.py
@@ -423,9 +423,23 @@ class matrix_power(Function):
     def backward(ctx, grad_output):
         s, U, s_modified = ctx.saved_tensors
         exponent = ctx.exponent
-        return modeig_backward(
+        threshold = get_epsilon(s.dtype, "eigval_power")
+
+        # Gradient wrt the exponent
+        G = U.transpose(-1,-2) @ grad_output @ U
+        diag_G = torch.diagonal(G, dim1 = -2, dim2= -1)
+
+        s_safe = s.clamp(min = threshold)
+        exp_g = s_modified * torch.log(s_safe)
+
+        grad_exponent = torch.sum(diag_G * exp_g).view(1, 1)
+
+        # Gradient wrt X
+        grad_X = modeig_backward(
             grad_output, s, U, s_modified, matrix_power.derivative, exponent
-        ), None
+        )
+
+        return grad_X, grad_exponent
 
 
 class matrix_sqrt(Function):

--- a/spd_learn/functional/core.py
+++ b/spd_learn/functional/core.py
@@ -426,7 +426,7 @@ class matrix_power(Function):
         threshold = get_epsilon(s.dtype, "eigval_power")
 
         # Gradient w.r.t the exponent
-        G = U.transpose(-1, -2) @ grad_output @ U
+        G = U.mT @ grad_output @ U
         diag_G = torch.diagonal(G, dim1=-2, dim2=-1)
 
         s_safe = s.clamp(min=threshold)

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -122,7 +122,8 @@ def test_matrix_power():
 
     assert matrix_power.apply(X, 3.0).allclose(X @ X @ X)
     X.requires_grad_(True)
-    assert gradcheck(safe_matrix_power, (X, 0.1))
+    exponent = torch.tensor(0.1, dtype=torch.double, requires_grad=True)
+    assert gradcheck(safe_matrix_power, (X, exponent))
 
 
 def test_matrix_sqrt():


### PR DESCRIPTION
### Context
This PR fixes issue https://github.com/spdlearn/spd_learn/issues/25  regarding the backward behavior of `matrix_power`, where the gradient with respect to the exponent parameter was previously not implemented.

### Changes 
This PR updates the backward function of `matrix_power` to include a gradient computation w.r.t. the exponent parameter. 

### Tests
Running pytest locally results in 8 failing tests.
These failures are also present on the current main branch, indicating they are unrelated to this PR.

### Authors
- @Emma5938
- @Marco-Congedo
- @isacostamaia 
- SAID Salem

### Affiliation 
Gipsa-lab, University of Grenoble Alpes, CNRS, Grenoble INP 

