### PR TITLE
fix: matrix_power exponent gradient — clamp subgradient + Python-scalar support

### DIFF
--- a/spd_learn/functional/core.py
+++ b/spd_learn/functional/core.py
@@ -377,8 +377,9 @@ class matrix_power(Function):
     ----------
     X : torch.Tensor
         Symmetric matrix of shape `(..., n, n)`.
-    exponent : torch.Tensor
-        Exponent to raise the matrix to.
+    exponent : float or torch.Tensor
+        Exponent to raise the matrix to. Python scalars are cast internally
+        to a 0-d tensor.
 
     Returns
     -------
@@ -414,6 +415,7 @@ class matrix_power(Function):
 
     @staticmethod
     def forward(ctx, X, exponent):
+        exponent = torch.as_tensor(exponent, dtype=X.dtype, device=X.device)
         output, s, U, s_modified = modeig_forward(X, matrix_power.applied_fct, exponent)
         ctx.save_for_backward(s, U, s_modified)
         ctx.exponent = exponent
@@ -423,21 +425,21 @@ class matrix_power(Function):
     def backward(ctx, grad_output):
         s, U, s_modified = ctx.saved_tensors
         exponent = ctx.exponent
-        threshold = get_epsilon(s.dtype, "eigval_power")
 
-        # Gradient w.r.t the exponent
-        G = U.mT @ grad_output @ U
-        diag_G = torch.diagonal(G, dim1=-2, dim2=-1)
-
-        s_safe = s.clamp(min=threshold)
-        exp_g = s_modified * torch.log(s_safe)
-
-        grad_exponent = torch.sum(diag_G * exp_g, dim=-1).sum().reshape_as(exponent)
-
-        # Gradient w.r.t X
         grad_X = modeig_backward(
             grad_output, s, U, s_modified, matrix_power.derivative, exponent
         )
+
+        grad_exponent = None
+        if ctx.needs_input_grad[1]:
+            threshold = get_epsilon(s.dtype, "eigval_power")
+            diag_G = torch.diagonal(U.mT @ grad_output @ U, dim1=-2, dim2=-1)
+            exp_g = s_modified * torch.log(s.clamp(min=threshold))
+            # match the X-gradient: subgradient 0 at clamped eigenvalues
+            exp_g = torch.where(s > threshold, exp_g, 0.0)
+            grad_exponent = (
+                torch.sum(diag_G * exp_g, dim=-1).sum().reshape_as(exponent)
+            )
 
         return grad_X, grad_exponent
 

--- a/spd_learn/functional/core.py
+++ b/spd_learn/functional/core.py
@@ -437,9 +437,7 @@ class matrix_power(Function):
             exp_g = s_modified * torch.log(s.clamp(min=threshold))
             # match the X-gradient: subgradient 0 at clamped eigenvalues
             exp_g = torch.where(s > threshold, exp_g, 0.0)
-            grad_exponent = (
-                torch.sum(diag_G * exp_g, dim=-1).sum().reshape_as(exponent)
-            )
+            grad_exponent = torch.sum(diag_G * exp_g, dim=-1).sum().reshape_as(exponent)
 
         return grad_X, grad_exponent
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -125,6 +125,16 @@ def test_matrix_power():
     exponent = torch.tensor(0.1, dtype=torch.double, requires_grad=True)
     assert gradcheck(safe_matrix_power, (X, exponent))
 
+    # Python-scalar exponent: backward must not crash
+    safe_matrix_power(X.detach().requires_grad_(True), 0.5).sum().backward()
+
+    # Near-singular input: exponent grad must follow subgradient-0 like X grad
+    X_tiny = torch.diag(torch.tensor([1e-30, 0.5, 1.0, 2.0], dtype=torch.double))
+    X_tiny.requires_grad_(True)
+    e_tiny = torch.tensor(-0.5, dtype=torch.double, requires_grad=True)
+    safe_matrix_power(X_tiny, e_tiny).sum().backward()
+    assert e_tiny.grad.abs().item() < 1.0
+
 
 def test_matrix_sqrt():
     from spd_learn.functional import ensure_sym, matrix_sqrt


### PR DESCRIPTION
### Context

Follow-up to #26, which added a gradient w.r.t. the `exponent` parameter in `matrix_power.backward`. Two issues remained after that merge.

### Bug 1 — spurious huge exponent gradient at clamped eigenvalues

For numerical stability, eigenvalues below `get_epsilon(dtype, "eigval_power")` (~1e-13 for double) are clamped to that threshold. The **X-gradient** correctly picks subgradient 0 there:

```python
# core.py:412-413 (existing)
s_deriv = exponent * s_clamped.pow(exponent - 1.0)
s_deriv[s <= threshold] = 0   # subgradient 0 at clamped eigenvalues
```

But the **new exponent-gradient** kept flowing through `s_modified * log(s_safe) = threshold^e * log(threshold)`. For `s = 1e-30, e = -0.5`, this produces `grad_exponent ≈ -6.18e+07` instead of the expected ~`-0.49`.

This makes any training that touches near-singular SPDs through `matrix_power` blow up.

### Bug 2 — Python-scalar exponent crashes `backward`

Several internal call sites pass a Python `float`:

```python
# modules/liebn.py:289
matrix_power.apply(X, self.theta)   # self.theta is a Python float
```

PR #26's backward does `.reshape_as(exponent)` which crashes with `TypeError: reshape_as(): argument 'other' must be Tensor, not float`. Reproduced on `main`.

### Fix

1. `forward`: cast `exponent` to a 0-d tensor on `X`'s device/dtype via `torch.as_tensor` so the `.reshape_as` call always sees a tensor.
2. `backward`: apply the same subgradient-0 convention to `exp_g` via `torch.where(s > threshold, exp_g, 0.0)`.
3. Skip the exponent-gradient computation (including the n×n matmul `U.mT @ grad_output @ U`) when `ctx.needs_input_grad[1]` is False — saves work on the common path where a Python scalar is passed.
4. Docstring updated: `exponent : float or torch.Tensor`.

Net diff: +25 / −13 lines.

### Tests

`tests/test_functional.py::test_matrix_power` now covers:
- existing `gradcheck` with 0-d tensor exponent (unchanged)
- backward with a Python-scalar exponent doesn't crash
- exponent gradient stays bounded (< 1) on a near-singular input where the bug previously produced ~6e7

Full suite: **707 passed, 146 skipped** (no regressions).

### Authors
- @bruAristimunha