### PR TITLE
Fix: set Cayley as default if orthogonal_map is None

### DIFF
--- a/spd_learn/modules/bilinear.py
+++ b/spd_learn/modules/bilinear.py
@@ -161,7 +161,7 @@ class BiMap(nn.Module):
         out_features: int,
         depthwise: int = 1,
         parametrized: bool = True,
-        orthogonal_map: Optional[str] = None,
+        orthogonal_map: Optional[str] = "cayley",
         init_method: Literal[
             "kaiming_uniform", "orthogonal", "stiefel"
         ] = "kaiming_uniform",

--- a/spd_learn/modules/bilinear.py
+++ b/spd_learn/modules/bilinear.py
@@ -65,8 +65,8 @@ class BiMap(nn.Module):
     parametrized : bool, default=True
         If `True`, the weight matrix `W` is parametrized as an orthogonal
         matrix via projection/retraction on the Stiefel manifold.
-    orthogonal_map : str, optional
-        The method used for orthogonal parametrization.
+    orthogonal_map : {"cayley", "matrix_exp", "householder"}, optional
+        The method used for orthogonal parametrization. If `None`, defaults to "cayley".
     init_method : {"kaiming_uniform", "orthogonal", "stiefel"}, default="kaiming_uniform"
         The initialization method for the weight matrix.
     seed : int, optional
@@ -161,7 +161,7 @@ class BiMap(nn.Module):
         out_features: int,
         depthwise: int = 1,
         parametrized: bool = True,
-        orthogonal_map: Optional[str] = "cayley",
+        orthogonal_map: Optional[Literal["cayley", "matrix_exp", "householder"]] = None,
         init_method: Literal[
             "kaiming_uniform", "orthogonal", "stiefel"
         ] = "kaiming_uniform",
@@ -211,7 +211,11 @@ class BiMap(nn.Module):
 
         if self.parametrized:
             parametrizations.orthogonal(
-                module=self, name="weight", orthogonal_map=self.orthogonal_map
+                module=self,
+                name="weight",
+                orthogonal_map=(
+                    "cayley" if self.orthogonal_map is None else self.orthogonal_map
+                ),
             )
 
     @torch.no_grad()


### PR DESCRIPTION
Current code passes `orthogonal_map=None` to `torch.nn.utils.parametrizations.orthogonal` in the BiMap. This PR changes this by instead having `orthogonal_map="cayley"` if BiMap uses None.

When using a squared BiMap the current code work fine because pytorch will default to `orthogonal_map=matrix_exp`, but if using a rectangular one then it uses `orthogonal_map=householder`. This has some issues when using weight decay which can cause `Q=0`, consequently `W=0`,and BiMap then outputs a zero matrix.

The current change can be seen when running the `moabb_hydra_benchmark.py` before and after the change:

| Model     | Accuracy (None) -> (cayley) |
| --------- | --------------------------: |
| SPDNet    |            0.6493 -> 0.6493 |
| TSMNet    |            0.2500 -> 0.6562 |
| EEGSPDNet |            0.2500 -> 0.5729 |

This also led to a nice speedup in my machine (ran using pytest-benchmark):

| Name (time in s)                         | cayley | None |  ΔMean |
| ---------------------------------------- | ---------------: | ----------------: | -----: |
| test_correctness_spd_learn[PhaseSPDNet]  |           1.8265 |            1.8220 |  -0.2% |
| test_correctness_spd_learn[TSMNet]       |           2.7115 |            2.7772 |  +2.4% |
| test_correctness_spd_learn[TensorCSPNet] |          11.5278 |           12.9794 | +12.6% |
| test_correctness_spd_learn[Green]        |          20.4135 |           21.3182 |  +4.4% |
| test_correctness_spd_learn[EEGSPDNet]    |          37.1012 |           49.6138 | +33.7% |
