### PR TITLE
Fix: cuda test errors due to device mismatch

### DIFF
--- a/spd_learn/modules/wavelet.py
+++ b/spd_learn/modules/wavelet.py
@@ -129,7 +129,7 @@ class WaveletConv(nn.Module):
         self.stride = stride
         self.scaling = scaling
         self.dtype = dtype
-        self.device = device if device is not None else torch.device("cpu")
+        device = device if device is not None else torch.device("cpu")
 
         tmax = kernel_width_s / 2.0
         tmin = -tmax
@@ -204,5 +204,9 @@ class WaveletConv(nn.Module):
             X_conv = X_conv.permute(0, 3, 2, 1, 4).contiguous()
             n_batch, n_freqs, n_sensors, n_epochs, n_times = X_conv.shape
             X_conv = X_conv.view(n_batch, n_freqs, n_sensors, n_epochs * n_times)
+        else:
+            raise ValueError(
+                f"Wavelet expects a 3D or 4D input, but received shape {tuple(X.shape)}"
+            )
 
         return X_conv.to(device=X.device, dtype=self.dtype)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -167,7 +167,7 @@ def test_module_dtype(module_name, dtype, device):
     elif module_name == "WaveletConv":
         # WaveletConv processes raw time series, not covariance matrices
         # It uses complex wavelets internally but outputs the dtype it was initialized with
-        x = torch.randn(2, 10, 1000, dtype=dtype)
+        x = torch.randn(2, 10, 1000, dtype=dtype, device=device)
         with torch.no_grad():
             out = module(x)
         assert out.dtype == dtype

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -317,7 +317,7 @@ def test_bimap_instantiation_and_shape(
     # Check output shape: (batch_size, out_features, out_features)
     expected_shape = (batch_size, out_f, out_f)
     assert Y.shape == expected_shape, f"Failed shape check for {desc}"
-    assert Y.device == device, f"Failed device check for {desc}"
+    assert Y.device == X.device, f"Failed device check for {desc}"
     assert Y.dtype == dtype, f"Failed dtype check for {desc}"
 
 


### PR DESCRIPTION
This PR fixes #27.

One issue was that on `test_module_dtype` some models had a `CovLayer` that was making sure everyone was on the same device, while `WaveletConv` receives a raw input, so `x` needs to be on the correct device before being passed to it. 

The other was that on `test_bimap_instantiation_and_shape`, since, for CUDA, these may be represented as cuda:0 and cuda, which are not equal as `torch.device` objects. The test now compares `Y.device` with `X.device`, the exact device of the input tensor. 

Also changed the `self.device` to `device` for the `WaveletConv`, as that seems to be the intended behavior.